### PR TITLE
Pydantic's model_validate() in favor of deprecated parse_obj()

### DIFF
--- a/parse_data.py
+++ b/parse_data.py
@@ -14,7 +14,7 @@ class Sample(BaseModel):
 
 with open('paper_dataset.json') as f:
     raw_data = json.load(f)
-    data = [Sample.parse_obj(d) for d in raw_data]
+    data = [Sample.model_validate(d) for d in raw_data]
 
 print("First query: ", data[0].query)
 print("First paper of first query: ", data[0].papers[0].title)


### PR DESCRIPTION
I was trying to run the `parse_data.py` script to examine the FaVe dataset. Pydantic's `parse_obj()` is now deprecated in favor of `model_validate()` I believe (correct me if I'm wrong), so I added the fix. 